### PR TITLE
Addon tab overhaul

### DIFF
--- a/gui/addon_manager.py
+++ b/gui/addon_manager.py
@@ -1,12 +1,11 @@
 import json
+import shutil
 from PyQt6.QtWidgets import QListWidgetItem, QMessageBox
-from PyQt6.QtCore import Qt, QObject, pyqtSignal
+from PyQt6.QtCore import Qt, QObject
 from core.folder_setup import folder_setup
 
 
 class AddonManager(QObject):
-    addon_list_updated = pyqtSignal()
-
     def __init__(self, settings_manager):
         super().__init__()
         self.settings_manager = settings_manager
@@ -37,7 +36,7 @@ class AddonManager(QObject):
 
         # add addons to list widget with group splitters
         for addon_type in addon_groups:
-            if addon_type != "unknown":
+            if addon_type != "unknown" and addon_groups[addon_type]:
                 splitter = QListWidgetItem("──── " + str.title(addon_type) + " ────")
                 splitter.setFlags(Qt.ItemFlag.NoItemFlags)
                 splitter.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -162,10 +161,9 @@ class AddonManager(QObject):
 
         errors = []
         for display_name, folder_name in zip(selected_addon_names, selected_folder_names):
-            addon_path = folder_setup.addons_dir / folder_name  # ← Use folder name
+            addon_path = folder_setup.addons_dir / folder_name
             if addon_path.exists() and addon_path.is_dir():
                 try:
-                    import shutil
                     shutil.rmtree(addon_path)
                 except Exception as e:
                     errors.append(f"Failed to delete {display_name}: {str(e)}")

--- a/gui/addon_manager.py
+++ b/gui/addon_manager.py
@@ -45,6 +45,8 @@ class AddonManager(QObject):
 
                 for addon_info_dict in addon_groups[addon_type]:
                     item = QListWidgetItem(addon_info_dict['addon_name'])
+                    item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+                    item.setCheckState(Qt.CheckState.Unchecked)
                     addons_list.addItem(item)
                     self.addons_file_paths[addon_info_dict['addon_name']] = addon_info_dict
 
@@ -57,6 +59,8 @@ class AddonManager(QObject):
 
             for addon_info_dict in addon_groups["unknown"]:
                 item = QListWidgetItem(addon_info_dict['addon_name'])
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+                item.setCheckState(Qt.CheckState.Unchecked)
                 addons_list.addItem(item)
                 self.addons_file_paths[addon_info_dict['addon_name']] = addon_info_dict
 

--- a/gui/addon_panel.py
+++ b/gui/addon_panel.py
@@ -47,18 +47,18 @@ class AddonPanel(QWidget):
         addons_group.setLayout(addons_layout)
         panels_layout.addWidget(addons_group)
 
-        # middle: load order panel
-        self.load_order_panel = LoadOrderPanel()
-        self.load_order_panel.load_order_changed.connect(self.on_load_order_changed)
-        panels_layout.addWidget(self.load_order_panel)
-
-        # right: description
+        # middle: description
         description_group = QGroupBox("Details")
         description_layout = QVBoxLayout()
         self.addon_description = AddonDescription()
         description_layout.addWidget(self.addon_description)
         description_group.setLayout(description_layout)
         panels_layout.addWidget(description_group)
+
+        # right: load order panel
+        self.load_order_panel = LoadOrderPanel()
+        self.load_order_panel.load_order_changed.connect(self.on_load_order_changed)
+        panels_layout.addWidget(self.load_order_panel)
 
         layout.addLayout(panels_layout)
 

--- a/gui/interface.py
+++ b/gui/interface.py
@@ -61,7 +61,7 @@ class Interface(QObject):
                         continue
 
                     for src_path in addon_dir.glob('**/*'):
-                        if src_path.is_file() and src_path.name != 'mod.json':
+                        if src_path.is_file() and src_path.name != 'mod.json' and src_path.name != 'sound.cache':
                             # skip sound script files from addons (we'll use our versions)
                             rel_path = src_path.relative_to(addon_dir)
                             if (rel_path.parts[0] == 'scripts' and

--- a/gui/load_order_panel.py
+++ b/gui/load_order_panel.py
@@ -44,7 +44,8 @@ class LoadOrderPanel(QWidget):
             # strip [#N] prefix and ⚠️suffix if present
             clean_name = text.split('] ', 1)[-1].replace(' ⚠️', '')
             load_order.append(clean_name)
-        return load_order
+        # reverse the order so that top item is installed last and wins conflicts
+        return list(reversed(load_order))
 
     def update_display(self, addon_contents):
         # add numbering and conflict detection to load order list
@@ -138,6 +139,6 @@ class LoadOrderPanel(QWidget):
         # restore load order from saved list
         self.load_order_list.blockSignals(True)
         self.load_order_list.clear()
-        for name in addon_names:
+        for name in reversed(addon_names):
             self.load_order_list.addItem(name)
         self.load_order_list.blockSignals(False)

--- a/gui/load_order_panel.py
+++ b/gui/load_order_panel.py
@@ -1,0 +1,143 @@
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QGroupBox, QListWidget, QListWidgetItem, QAbstractItemView
+from PyQt6.QtCore import pyqtSignal
+
+
+class LoadOrderPanel(QWidget):
+    load_order_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.load_order_list = None
+        self.setup_ui()
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        load_order_group = QGroupBox("Load Order (Drag to Modify)")
+        load_order_layout = QVBoxLayout()
+
+        self.load_order_list = QListWidget()
+        self.load_order_list.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self.load_order_list.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
+        self.load_order_list.model().rowsMoved.connect(self.on_load_order_changed)
+
+        # hide selection highlight completely
+        self.load_order_list.setStyleSheet("""
+            QListWidget::item:selected {
+                background: transparent;
+            }
+        """)
+
+        load_order_layout.addWidget(self.load_order_list)
+        load_order_group.setLayout(load_order_layout)
+
+        layout.addWidget(load_order_group)
+
+    def on_load_order_changed(self):
+        self.load_order_changed.emit()
+
+    def get_load_order(self):
+        load_order = []
+        for i in range(self.load_order_list.count()):
+            text = self.load_order_list.item(i).text()
+            # strip [#N] prefix and ⚠️suffix if present
+            clean_name = text.split('] ', 1)[-1].replace(' ⚠️', '')
+            load_order.append(clean_name)
+        return load_order
+
+    def update_display(self, addon_contents):
+        # add numbering and conflict detection to load order list
+        try:
+            self.load_order_list.blockSignals(True)
+            load_order_items = []
+
+            # collect all items
+            for i in range(self.load_order_list.count()):
+                item = self.load_order_list.item(i)
+                load_order_items.append(item.text().split(' [#')[0].split('] ', 1)[-1].replace(' ⚠️', ''))
+
+            # rebuild with numbering and conflicts
+            self.load_order_list.clear()
+            total_items = len(load_order_items)
+            for pos, addon_name in enumerate(load_order_items):
+                priority_number = total_items - pos
+                display_text = f"[#{priority_number}] {addon_name}"
+
+                # check for conflicts
+                if addon_contents and addon_name in addon_contents:
+                    overwrites = {}
+                    addon_files = set(addon_contents[addon_name])
+
+                    # check against lower priority addons
+                    for other_pos, other_name in enumerate(load_order_items):
+                        if other_pos > pos and other_name in addon_contents:
+                            other_files = set(addon_contents[other_name])
+                            common_files = addon_files.intersection(other_files)
+                            if common_files:
+                                overwrites[other_name] = list(common_files)
+
+                    if overwrites:
+                        display_text += " ⚠️"
+                        tooltip = "Will overwrite:\n"
+                        for overwrite_addon, overwrite_files in overwrites.items():
+                            tooltip += f"• {overwrite_addon}: "
+                            if overwrite_files:
+                                tooltip += f"{len(overwrite_files)} files including {overwrite_files[0]}\n"
+                            else:
+                                tooltip += "Unknown files\n"
+
+                        item = QListWidgetItem(display_text)
+                        item.setToolTip(tooltip)
+                        self.load_order_list.addItem(item)
+                    else:
+                        self.load_order_list.addItem(display_text)
+                else:
+                    self.load_order_list.addItem(display_text)
+
+            self.load_order_list.blockSignals(False)
+
+        except Exception as e:
+            print(f"Error in update_display: {e}")
+            import traceback
+            traceback.print_exc()
+
+    def sync_from_checked_addons(self, checked_addon_names):
+        # update load order list from checked addons
+        self.load_order_list.blockSignals(True)
+
+        # get current load order
+        existing_order = []
+        for i in range(self.load_order_list.count()):
+            text = self.load_order_list.item(i).text()
+            clean_name = text.split('] ', 1)[-1].replace(' ⚠️', '')
+            existing_order.append(clean_name)
+
+        # add new items at top, then keep existing order
+        new_order = []
+        for name in checked_addon_names:
+            if name not in existing_order:
+                new_order.append(name)
+
+        # then add existing items that are still checked
+        for name in existing_order:
+            if name in checked_addon_names:
+                new_order.append(name)
+
+        # update the list
+        self.load_order_list.clear()
+        for name in new_order:
+            self.load_order_list.addItem(name)
+
+        self.load_order_list.blockSignals(False)
+
+    def clear(self):
+        self.load_order_list.clear()
+
+    def restore_order(self, addon_names):
+        # restore load order from saved list
+        self.load_order_list.blockSignals(True)
+        self.load_order_list.clear()
+        for name in addon_names:
+            self.load_order_list.addItem(name)
+        self.load_order_list.blockSignals(False)

--- a/gui/mod_descriptor.py
+++ b/gui/mod_descriptor.py
@@ -1,10 +1,118 @@
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QLabel, QScrollArea, QFrame)
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QLabel, QScrollArea, QFrame, QDialog,
+                             QLineEdit, QTextEdit, QPushButton, QHBoxLayout, QComboBox,
+                             QFormLayout, QMessageBox)
 from core.constants import MOD_TYPE_COLORS
+from core.folder_setup import folder_setup
+import json
+
+
+class ModJsonEditor(QDialog):
+    addon_updated = pyqtSignal()
+
+    def __init__(self, addon_name, addon_info, parent=None):
+        super().__init__(parent)
+        self.gamebanana_edit = None
+        self.description_edit = None
+        self.version_edit = None
+        self.type_combo = None
+        self.name_edit = None
+        self.addon_name = addon_name
+        self.addon_info = addon_info
+        self.setWindowTitle(f"Edit {addon_name}")
+        self.setMinimumSize(500, 400)
+        self.setup_ui()
+        self.load_data()
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        # form layout
+        form_layout = QFormLayout()
+
+        # addon name
+        self.name_edit = QLineEdit()
+        form_layout.addRow("Addon Name:", self.name_edit)
+
+        # type dropdown
+        self.type_combo = QComboBox()
+        self.type_combo.addItems(["Skin", "Model", "Texture", "Misc", "Animation", "Experimental", "HUD", "Sound"])
+        form_layout.addRow("Type:", self.type_combo)
+
+        # version
+        self.version_edit = QLineEdit()
+        form_layout.addRow("Version:", self.version_edit)
+
+        # description
+        self.description_edit = QTextEdit()
+        self.description_edit.setMaximumHeight(100)
+        form_layout.addRow("Description:", self.description_edit)
+
+        # gamebanana link
+        self.gamebanana_edit = QLineEdit()
+        self.gamebanana_edit.setPlaceholderText("https://gamebanana.com/mods/...")
+        form_layout.addRow("GameBanana Link:", self.gamebanana_edit)
+
+        layout.addLayout(form_layout)
+
+        # buttons
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        button_layout.addWidget(cancel_btn)
+
+        save_btn = QPushButton("Save")
+        save_btn.clicked.connect(self.save_changes)
+        button_layout.addWidget(save_btn)
+
+        layout.addLayout(button_layout)
+
+    def load_data(self):
+        self.name_edit.setText(self.addon_info.get("addon_name", ""))
+
+        addon_type = self.addon_info.get("type", "Unknown")
+        index = self.type_combo.findText(addon_type, Qt.MatchFlag.MatchFixedString)
+        if index >= 0:
+            self.type_combo.setCurrentIndex(index)
+
+        self.version_edit.setText(self.addon_info.get("version", ""))
+        self.description_edit.setPlainText(self.addon_info.get("description", ""))
+        self.gamebanana_edit.setText(self.addon_info.get("gamebanana_link", ""))
+
+    def save_changes(self):
+        folder_name = self.addon_info.get("file_path", self.addon_name)
+        mod_json_path = folder_setup.addons_dir / folder_name / "mod.json"
+
+        # build updated json
+        updated_data = {
+            "addon_name": self.name_edit.text(),
+            "type": self.type_combo.currentText(),
+            "version": self.version_edit.text(),
+            "description": self.description_edit.toPlainText(),
+            "gamebanana_link": self.gamebanana_edit.text()
+        }
+
+        # preserve existing contents field if it exists
+        if "contents" in self.addon_info:
+            updated_data["contents"] = self.addon_info["contents"]
+
+        try:
+            with open(mod_json_path, 'w') as f:
+                json.dump(updated_data, f, indent=2)
+            self.addon_updated.emit()
+            self.accept()
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save mod.json: {str(e)}")
+
 
 class AddonDescription(QWidget):
+    addon_modified = pyqtSignal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.gamebanana_label = None
         self.content_layout = None
         self.name_label = None
         self.type_label = None
@@ -12,6 +120,9 @@ class AddonDescription(QWidget):
         self.description_label = None
         self.features_label = None
         self.features_list = None
+        self.edit_button = None
+        self.current_addon_name = None
+        self.current_addon_info = None
         self.setup_ui()
 
     def setup_ui(self):
@@ -50,6 +161,11 @@ class AddonDescription(QWidget):
         self.description_label.setWordWrap(True)
         self.content_layout.addWidget(self.description_label)
 
+        self.gamebanana_label = QLabel()
+        self.gamebanana_label.setOpenExternalLinks(True)
+        self.gamebanana_label.setWordWrap(True)
+        self.content_layout.addWidget(self.gamebanana_label)
+
         self.features_label = QLabel("Contains:")
         self.features_label.setStyleSheet("font-weight: bold;")
         self.content_layout.addWidget(self.features_label)
@@ -59,6 +175,12 @@ class AddonDescription(QWidget):
         self.content_layout.addWidget(self.features_list)
 
         self.content_layout.addStretch()
+
+        # edit button
+        self.edit_button = QPushButton("Edit mod.json")
+        self.edit_button.clicked.connect(self.open_editor)
+        self.content_layout.addWidget(self.edit_button)
+
         scroll.setWidget(content)
         layout.addWidget(scroll)
 
@@ -75,13 +197,15 @@ class AddonDescription(QWidget):
         """)
 
     def update_content(self, addon_name: str, addon_info: dict):
+        self.current_addon_name = addon_name
+        self.current_addon_info = addon_info
         self.name_label.setText(addon_name)
 
         addon_type = addon_info.get("type", "Unknown")
         self.type_label.setText(addon_type.upper())
         self.set_type_style(addon_type)
 
-        version = addon_info.get("version", [])
+        version = addon_info.get("version", "")
         if version:
             self.version_label.setText("Version: " + version)
             self.version_label.setStyleSheet(f"""
@@ -93,6 +217,14 @@ class AddonDescription(QWidget):
 
         self.description_label.setText(addon_info.get("description", ""))
 
+        # gamebanana link
+        gamebanana_link = addon_info.get("gamebanana_link", "")
+        if gamebanana_link and gamebanana_link.startswith("https://gamebanana.com"):
+            self.gamebanana_label.setText(f'<a href="{gamebanana_link}">View on GameBanana</a>')
+            self.gamebanana_label.show()
+        else:
+            self.gamebanana_label.hide()
+
         contents = addon_info.get("contents", [])
         if contents:
             self.features_list.setText("• " + "\n• ".join(contents))
@@ -102,9 +234,35 @@ class AddonDescription(QWidget):
             self.features_label.hide()
             self.features_list.hide()
 
+        self.edit_button.show()
+
     def clear(self):
+        self.current_addon_name = None
+        self.current_addon_info = None
         self.name_label.clear()
         self.type_label.clear()
         self.description_label.setText("Select an addon to view details")
+        self.gamebanana_label.hide()
         self.features_label.hide()
         self.features_list.hide()
+        self.edit_button.hide()
+
+    def open_editor(self):
+        if self.current_addon_name and self.current_addon_info:
+            dialog = ModJsonEditor(self.current_addon_name, self.current_addon_info, self)
+            dialog.addon_updated.connect(self.addon_modified.emit)
+            dialog.addon_updated.connect(self.refresh_current_addon)
+            dialog.exec()
+
+    def refresh_current_addon(self):
+        if self.current_addon_name and self.current_addon_info:
+            folder_name = self.current_addon_info.get("file_path", self.current_addon_name)
+            mod_json_path = folder_setup.addons_dir / folder_name / "mod.json"
+            try:
+                with open(mod_json_path, 'r') as f:
+                    updated_info = json.load(f)
+                    updated_info['file_path'] = folder_name
+                    self.update_content(updated_info.get("addon_name", self.current_addon_name), updated_info)
+            except Exception as e:
+                print(f"Error refreshing addon details: {e}")
+                self.clear()


### PR DESCRIPTION
## New 
- Added dedicated panel for managing addon installation order
- Replaced multi-select with checkboxes for selecting addons
- Added menu to delete addons via right-click
- Moved "Refresh Addons" and "Open Addons Folder" to Options dropdown
- Added "Edit mod.json" button in Details panel for editing addon metadata
  - Fixes #77

## Bug Fixes
- Fixed reversed installation order, top items now correctly install last
- Order does not reverse after app restarts
- Prevented sound.cache files from being included in VPK during installation
- Category headers now hidden when no addons match that category
  - Fixes #78

## UI Changes
- Swapped Details and Load Order panels (now: Addons | Details | Load Order)
- UI is no longer QSplitter based and just uses QHBoxLayout

## Files Modified
- `gui/interface.py` - Added sound.cache to exclusion filter
- `gui/addon_panel.py` - Added checkboxes, context menu, reorganized panel layout
- `gui/main_window.py` - Moved actions to Options menu
- `gui/mod_descriptor.py` - Added mod.json editor dialog
- `gui/addon_manager.py` - Hide empty category headers
- `gui/load_order_panel.py` - (New) Load order management widget
