### PR TITLE
ci(dependabot): add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: chore
+      include: scope
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
Enables dependabot to notify and create PRs when a dependency's version should be bumped.
